### PR TITLE
fix: Verificación de censo se hacía con códigos postales de Madrid

### DIFF
--- a/app/models/custom/officing/residence.rb
+++ b/app/models/custom/officing/residence.rb
@@ -1,0 +1,14 @@
+require_dependency Rails.root.join("app", "models", "officing", "residence").to_s
+
+class Officing::Residence
+  validate :residence_in_pto_de_la_cruz
+
+  def residence_in_pto_de_la_cruz
+    return if errors.any?
+
+    unless residency_valid?
+      store_failed_census_call
+      errors.add(:residence_in_pto_de_la_cruz, false)
+    end
+  end
+end

--- a/app/models/custom/verification/residence.rb
+++ b/app/models/custom/verification/residence.rb
@@ -1,18 +1,18 @@
 require_dependency Rails.root.join("app", "models", "verification", "residence").to_s
 
 class Verification::Residence
-  validate :postal_code_in_madrid
-  validate :residence_in_madrid
+  validate :postal_code_in_pto_de_la_cruz
+  validate :residence_in_pto_de_la_cruz
 
-  def postal_code_in_madrid
+  def postal_code_in_pto_de_la_cruz
     errors.add(:postal_code, I18n.t("verification.residence.new.error_not_allowed_postal_code")) unless valid_postal_code?
   end
 
-  def residence_in_madrid
+  def residence_in_pto_de_la_cruz
     return if errors.any?
 
     unless residency_valid?
-      errors.add(:residence_in_madrid, false)
+      errors.add(:residence_in_pto_de_la_cruz, false)
       store_failed_attempt
       Lock.increase_tries(user)
     end
@@ -21,6 +21,6 @@ class Verification::Residence
   private
 
     def valid_postal_code?
-      postal_code =~ /^280/
+      postal_code == '38400'
     end
 end

--- a/app/views/custom/officing/residence/_errors.html.erb
+++ b/app/views/custom/officing/residence/_errors.html.erb
@@ -1,0 +1,14 @@
+<% if @residence.errors[:residence_in_pto_de_la_cruz].present? %>
+
+  <div id="error_explanation" data-alert class="callout alert" data-closable>
+    <button class="close-button" aria-label="<%= t("application.close") %>" type="button" data-close>
+      <span aria-hidden="true">&times;</span>
+    </button>
+    <%= t("officing.residence.new.error_verifying_census") %>
+  </div>
+
+<% else %>
+  <%= render "shared/errors",
+             resource: @residence,
+             message: t("officing.residence.new.form_errors") %>
+<% end %>

--- a/app/views/custom/verification/residence/_errors.html.erb
+++ b/app/views/custom/verification/residence/_errors.html.erb
@@ -1,0 +1,14 @@
+<% if @residence.errors[:residence_in_pto_de_la_cruz].present? %>
+
+  <div id="error_explanation" data-alert class="callout alert" data-closable>
+    <button class="close-button" aria-label="<%= t("application.close") %>" type="button" data-close>
+      <span aria-hidden="true">&times;</span>
+    </button>
+    <%= t("verification.residence.new.error_verifying_census") %>
+  </div>
+
+<% else %>
+  <%= render "shared/errors",
+             resource: @residence,
+             message: t("verification.residence.new.form_errors") %>
+<% end %>

--- a/lib/census_api.rb
+++ b/lib/census_api.rb
@@ -110,7 +110,7 @@ class CensusApi
             },
             datos_vivienda: {
               item: {
-                codigo_postal: "28013",
+                codigo_postal: "38400",
                 codigo_distrito: "01"
               }
             }

--- a/spec/factories/verifications.rb
+++ b/spec/factories/verifications.rb
@@ -3,7 +3,7 @@ FactoryBot.define do
     sequence(:document_number) { |n| "DOC_NUMBER#{n}" }
     document_type { 1 }
     date_of_birth { Date.new(1970, 1, 31) }
-    postal_code { "28002" }
+    postal_code { "38400" }
   end
   factory :local_census_records_import, class: "LocalCensusRecords::Import" do
     file do
@@ -19,11 +19,11 @@ FactoryBot.define do
     document_number
     document_type    { "1" }
     date_of_birth    { Time.zone.local(1980, 12, 31).to_date }
-    postal_code      { "28013" }
+    postal_code      { "38400" }
     terms_of_service { "1" }
 
     trait :invalid do
-      postal_code { "28001" }
+      postal_code { "38400" }
     end
   end
 
@@ -32,7 +32,7 @@ FactoryBot.define do
     document_number
     document_type { 1 }
     date_of_birth { Date.new(1900, 1, 1) }
-    postal_code { "28000" }
+    postal_code { "38400" }
   end
 
   factory :verification_sms, class: "Verification::Sms" do
@@ -61,6 +61,6 @@ FactoryBot.define do
     document_number
     document_type { "1" }
     date_of_birth { Date.new(1980, 12, 31) }
-    postal_code { "28013" }
+    postal_code { "38400" }
   end
 end

--- a/spec/models/custom/verification/residence_spec.rb
+++ b/spec/models/custom/verification/residence_spec.rb
@@ -5,17 +5,13 @@ describe Verification::Residence do
 
   describe "verification" do
     describe "postal code" do
-      it "is valid with postal codes starting with 280" do
-        residence.postal_code = "28012"
-        residence.valid?
-        expect(residence.errors[:postal_code]).to be_empty
-
-        residence.postal_code = "28023"
+      it "is valid with postal code 38400" do
+        residence.postal_code =  "38400"
         residence.valid?
         expect(residence.errors[:postal_code]).to be_empty
       end
 
-      it "is not valid with postal codes not starting with 280" do
+      it "is not valid with other postal codes" do
         residence.postal_code = "12345"
         residence.valid?
         expect(residence.errors[:postal_code].size).to eq(1)

--- a/spec/models/verification/residence_spec.rb
+++ b/spec/models/verification/residence_spec.rb
@@ -79,7 +79,8 @@ describe Verification::Residence do
 
   describe "tries" do
     it "increases tries after a call to the Census" do
-      residence.postal_code = "28011"
+      residence.document_number = "12345677Z"
+      residence.postal_code = "38400"
       residence.valid?
       expect(residence.user.lock.tries).to eq(1)
     end
@@ -93,16 +94,16 @@ describe Verification::Residence do
 
   describe "Failed census call" do
     it "stores failed census API calls" do
-      residence = build(:verification_residence, :invalid, document_number: "12345678Z")
+      residence = build(:verification_residence, :invalid, document_number: "12345677Z")
       residence.save
 
       expect(FailedCensusCall.count).to eq(1)
       expect(FailedCensusCall.first).to have_attributes(
         user_id:         residence.user.id,
-        document_number: "12345678Z",
+        document_number: "12345677Z",
         document_type:   "1",
         date_of_birth:   Date.new(1980, 12, 31),
-        postal_code:     "28001"
+        postal_code:     "38400"
       )
     end
   end


### PR DESCRIPTION
Cambia el código postal de Madrid (original del proyecto) al de Pto. de La Cruz en la verificación del censo, para que las validaciones se hagan correctamente.